### PR TITLE
Feat/inbound repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ lombok.config
 .env
 
 # Database config (Private)
-util/dbinfo.properties
+config/dbinfo.properties
 
 # Javadoc files
 docs/

--- a/src/repository/InboundRepo.java
+++ b/src/repository/InboundRepo.java
@@ -1,4 +1,29 @@
 package repository;
 
+import dto.InboundDTO;
+
+import java.util.List;
+
 public interface InboundRepo {
+
+    /**
+     * [입고 검수 기능]
+     * 입고테이블에서 입고승인 상태인 행을 가져온다.
+     * null 인 경우도 생각
+     */
+    List<InboundDTO> findByApprovedStatus();
+
+    /**
+     * [입고 검수 기능]
+     * 입고테이블에서 해당 ID의 입고 상태를 입고완료 상태로 변경한다.
+     * + 트리거를 통해 재고에 반영(update)
+     */
+    void updateCompletedStatus(int inboundId);
+
+    /**
+     *
+     */
+
+
+
 }

--- a/src/repository/InboundRepo.java
+++ b/src/repository/InboundRepo.java
@@ -34,5 +34,22 @@ public interface InboundRepo {
      */
     void registerInboundInfo(List<ProductVO> inboundList);
 
+    /**
+     * [입고 수정, 삭제 기능]
+     * 수정, 삭제할 입고 ID의 입고상태 정보를 가져온다.
+     */
+    String getInboundStatus(int inboundId);
+
+    /**
+     * [입고 수정 기능]
+     * 수정 가능 -> 입고ID, 입고상세 정보를 변경한다(update)
+     */
+    void updateInboundInfo(int inboundId, List<ProductVO> inboundList);
+
+    /**
+     * [입고 취소 기능]
+     * 입고 ID 삭제
+     */
+    void deleteInboundInfo(int inboundId);
 
 }

--- a/src/repository/InboundRepo.java
+++ b/src/repository/InboundRepo.java
@@ -1,6 +1,8 @@
 package repository;
 
 import dto.InboundDTO;
+import dto.ProductDTO;
+import vo.ProductVO;
 
 import java.util.List;
 
@@ -21,9 +23,16 @@ public interface InboundRepo {
     void updateCompletedStatus(int inboundId);
 
     /**
-     *
+     * [입고 요청 기능]
+     * 제품 테이블에서 모든 제품 정보를 가져온다.
      */
+    List<ProductDTO> getProductInfo();
 
+    /**
+     * [입고 요청 기능]
+     * 입고 요청 정보를 입고, 입고상세 테이블에 저장한다.
+     */
+    void registerInboundInfo(List<ProductVO> inboundList);
 
 
 }

--- a/src/repository/InboundRepoImpl.java
+++ b/src/repository/InboundRepoImpl.java
@@ -1,4 +1,17 @@
 package repository;
 
+import dto.InboundDTO;
+
+import java.util.List;
+
 public class InboundRepoImpl implements InboundRepo {
+    @Override
+    public List<InboundDTO> findByApprovedStatus() {
+        return null;
+    }
+
+    @Override
+    public void updateCompletedStatus(int inboundId) {
+
+    }
 }

--- a/src/repository/InboundRepoImpl.java
+++ b/src/repository/InboundRepoImpl.java
@@ -27,5 +27,20 @@ public class InboundRepoImpl implements InboundRepo {
 
     }
 
+    @Override
+    public String getInboundStatus(int inboundId) {
+        return null;
+    }
+
+    @Override
+    public void updateInboundInfo(int inboundId, List<ProductVO> inboundList) {
+
+    }
+
+    @Override
+    public void deleteInboundInfo(int inboundId) {
+
+    }
+
 
 }

--- a/src/repository/InboundRepoImpl.java
+++ b/src/repository/InboundRepoImpl.java
@@ -1,6 +1,8 @@
 package repository;
 
 import dto.InboundDTO;
+import dto.ProductDTO;
+import vo.ProductVO;
 
 import java.util.List;
 
@@ -14,4 +16,16 @@ public class InboundRepoImpl implements InboundRepo {
     public void updateCompletedStatus(int inboundId) {
 
     }
+
+    @Override
+    public List<ProductDTO> getProductInfo() {
+        return null;
+    }
+
+    @Override
+    public void registerInboundInfo(List<ProductVO> inboundList) {
+
+    }
+
+
 }


### PR DESCRIPTION
#28 

## 작업 내용
## 입고 Repository 기능 정의 

### 
[입고 검수 기능]
- 입고테이블에서 입고 승인 상태인 행을 가져온다.
- 입고테이블에서 해당 입고ID 상태를 입고 완료 상태로 변경한다. 

[입고 요청 기능]
- 제품 테이블에서 모든 제품 정보를 가져온다.
- 입고 요청 정보를 입고, 입고상세 테이블에 저장한다.

[입고 수정, 삭제 기능]
- 수정, 삭제할 입고 ID의 입고 상태 정보를 가져온다.

[입고 수정 기능]
- 입고ID, 입고상세 정보를 변경한다.

[입고 취소 기능]
- 입고ID 행 삭제
