### PR TITLE
Feat/member repo

### DIFF
--- a/src/common/member/MemberErrorCode.java
+++ b/src/common/member/MemberErrorCode.java
@@ -1,0 +1,20 @@
+package common.member;
+
+/*
+    예외 처리에 사용되는 에러 발생 text를 미리 정의하는 enum 클래스입니다.
+ */
+public enum MemberErrorCode {
+    DB_INSERT_ERROR("[DB]: 정보를 저장할 수 없습니다."),
+
+    NUMBER_NOT_FOUND("[Service]: 직원 번호를 찾을 수 없습니다");
+
+    private final String text;
+
+    MemberErrorCode(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/src/common/member/MemberText.java
+++ b/src/common/member/MemberText.java
@@ -1,0 +1,18 @@
+package common.member;
+
+/*
+    사용자에게 출력할 모든 text를 미리 정의하는 enum 클래스입니다.
+ */
+public enum MemberText {
+    MENU_HEADER("\n====================================\n[입고 관리 시스템]\n====================================");
+
+    private final String text;
+
+    MemberText(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/src/common/member/MemberValidCheck.java
+++ b/src/common/member/MemberValidCheck.java
@@ -1,0 +1,12 @@
+package common.member;
+
+/*
+    사용자 입력과 그 외 모든 유효성을 검사하는 클래스입니다.
+ */
+public class MemberValidCheck {
+
+    private static final String MENU_NUMBER_REGEX = "~~~";
+
+
+
+}

--- a/src/repository/MemberRepo.java
+++ b/src/repository/MemberRepo.java
@@ -49,5 +49,24 @@ public interface MemberRepo {
     Optional<MemberDTO> approvalMember(String memberNo);
 
 
+    /*
+     * [회원 간편/상세/권한별 조회 기능]
+     * 총관리자는 회원아이디와 권한을 기준으로 조회할 수 있다.
+     * 창고관리자는 회원아이디로 조회할 수 있다.
+     * 가맹점주는 본인 아이디로 조회할 수 있다.
+     *      ->현재는 조회 기준이 전부 String이라 t가 필요없긴함
+     * 회원이 존재하지 않을 경우  Optional 처리
+     */
+    <T> Optional<MemberDTO> loadMember(T serchValue);
+
+    /*
+     * [전체 회원 조회 기능]
+     * 저장된 전체 회원의 정보를 조회
+     * 회원이 존재하지 않아 리스트가 null값일 경우 Optional처리
+     */
+    Optional<List<MemberDTO>> allLoadMember();
+
+
+
 
 }

--- a/src/repository/MemberRepo.java
+++ b/src/repository/MemberRepo.java
@@ -67,6 +67,13 @@ public interface MemberRepo {
     Optional<List<MemberDTO>> allLoadMember();
 
 
+    /*
+     * [아이디 / 비밀번호 찾기 기능]
+     * 이메일로 아이디를 찾을 수 있다.
+     * 아이디로 비밀번호를 찾을 수 있다.
+     * 회원이 존재하지 않을 경우  Optional 처리
+     */
+    Optional<String>  searchLoginfo(String searchvalue);
 
 
 }

--- a/src/repository/MemberRepo.java
+++ b/src/repository/MemberRepo.java
@@ -40,5 +40,14 @@ public interface MemberRepo {
      */
     boolean requestMember(MemberDTO member);
 
+    /*
+     * [회원 승인 기능]
+     * 본사관리자는 가맹점주의 가입상태를 승인으로 변경
+     * 존재하지 않는 아이디의 경우  Optional 처리
+     * 트리거를 이용해 승인된 회원을 회원테이블에 추가 / 요청테이블에서 삭제
+     */
+    Optional<MemberDTO> approvalMember(String memberNo);
+
+
 
 }

--- a/src/repository/MemberRepo.java
+++ b/src/repository/MemberRepo.java
@@ -1,4 +1,44 @@
 package repository;
 
+import dto.MemberDTO;
+
+import java.util.List;
+import java.util.Optional;
+
 public interface MemberRepo {
+
+    /*
+     * [회원 등록 기능]
+     * 본사관리자가 신규 창고관리자를 등록
+     */
+     MemberDTO addMember(MemberDTO member);
+
+    /*
+     * [회원 수정 기능]
+     * 본사관리자는 회원의 정보를 수정할 수 있다
+     * 가맹점주는 본인 정보 수정
+     * 수정하려는 회원이 없을 경우  Optional 처리
+     */
+    Optional<MemberDTO> updateMember(String memberNo, MemberDTO updatemember);
+
+
+    /*
+     * [회원 삭제 기능]
+     * 본사관리자는 아이디로 회원정보를 삭제
+     * 가맹점주는 탈퇴
+     * 존재하지 않는 아이디의 경우  Optional 처리
+     * 삭제된 멤버의 간단한 정보(아이디,이름 등) 리턴
+     */
+    Optional<MemberDTO> deleteMember(String memberNo);
+
+
+    /*
+     * [회원 가입 기능]
+     * 가맹점주의 회원가입 요청을 요청테이블에 저장
+     * 요청상태 :승인대기
+     * 승인 실패의 경우 : 이미 존재하는 아이디의 경우 예외처리
+     */
+    boolean requestMember(MemberDTO member);
+
+
 }

--- a/src/repository/MemberRepoImpl.java
+++ b/src/repository/MemberRepoImpl.java
@@ -26,4 +26,9 @@ public class MemberRepoImpl implements MemberRepo {
         return false;
     }
 
+    @Override
+    public Optional<MemberDTO> approvalMember(String memberNo) {
+        return Optional.empty();
+    }
+
 }

--- a/src/repository/MemberRepoImpl.java
+++ b/src/repository/MemberRepoImpl.java
@@ -41,4 +41,10 @@ public class MemberRepoImpl implements MemberRepo {
         return Optional.empty();
     }
 
+    @Override
+    public Optional<String> searchLoginfo(String searchvalue) {
+        return Optional.empty();
+    }
+
+
 }

--- a/src/repository/MemberRepoImpl.java
+++ b/src/repository/MemberRepoImpl.java
@@ -1,4 +1,29 @@
 package repository;
 
+import dto.MemberDTO;
+
+import java.util.List;
+import java.util.Optional;
+
 public class MemberRepoImpl implements MemberRepo {
+    @Override
+    public MemberDTO addMember(MemberDTO member) {
+        return null;
+    }
+
+    @Override
+    public Optional<MemberDTO> updateMember(String memberNo, MemberDTO updatemember) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<MemberDTO> deleteMember(String memberNo) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean requestMember(MemberDTO member) {
+        return false;
+    }
+
 }

--- a/src/repository/MemberRepoImpl.java
+++ b/src/repository/MemberRepoImpl.java
@@ -31,4 +31,14 @@ public class MemberRepoImpl implements MemberRepo {
         return Optional.empty();
     }
 
+    @Override
+    public <T> Optional<MemberDTO> loadMember(T serchValue) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<List<MemberDTO>> allLoadMember() {
+        return Optional.empty();
+    }
+
 }


### PR DESCRIPTION
#30 
## 회원관리  Repository 기능 정의

[회원 등록 기능]
- 본사관리자가 신규 창고관리자를 등록
- 회원테이블에 add 

[회원 수정 기능]
- 본사관리자는 회원의 정보를 수정할 수 있다
- 가맹점주는 본인 정보 수정
-  회원테이블에 update 

[회원 삭제 기능]
- 본사관리자는 아이디로 회원정보를 삭제
- 가맹점주는 탈퇴
-  회원테이블에 delete

 [회원 가입 기능]
- 가맹점주의 회원가입 요청을 요청테이블 add
- 요청상태 :승인대기

[회원 승인 기능]
- 본사관리자는 가맹점주의 가입상태를 승인으로 변경

[회원 간편/상세/권한별 조회 기능]
- 총관리자는 회원아이디와 권한을 기준으로 조회할 수 있다.
- 창고관리자는 회원아이디로 조회할 수 있다.
- 가맹점주는 본인 아이디로 조회할 수 있다.

[전체 회원 조회 기능]
- 저장된 전체 회원의 정보를 조회

[아이디 / 비밀번호 찾기 기능]
- 이메일로 아이디를 찾을 수 있다.
- 아이디로 비밀번호를 찾을 수 있다.

### 예외처리 Optional 
### 아이디/비밀번호 찾기 기능을 조회메서드에서 함께 사용할 수 있었지만 기능분리를 위해 다른 메서드로 구현
- 아이디/비번찾기 메서드는 단순 String값(객체x)을 받아와 출력 
