### PR TITLE
Feat/member service 기능정의

### DIFF
--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -63,4 +63,19 @@ public interface MemberService {   /*
     MemberDTO searchAll();
 
 
+    /*
+     * [아이디 찾기 기능]
+     * searchLoginfo 호출
+     * 이메일로 아이디를 찾을 수 있다.
+     */
+    String findId(String memberEmail);
+
+    /*
+     * [비밀번호 찾기 기능]
+     * searchLoginfo 호출
+     * 아이디로 비밀번호를 찾을 수 있다.
+     */
+    String findPassword(String memberNo);
+
+
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -38,6 +38,24 @@ public interface MemberService {   /*
      */
     MemberDTO checkId (String memberNo);
 
+    /*
+    [회원아이디 간편조회 기능]
+    repo의 loadMember 호출해 해당 아이디의 아이디/이름/이메일 등 확인
+     */
+    MemberDTO searchSimple (String memberNo);
+
+    /*
+    [회원아이디 상세조회 기능]
+    repo의 loadMember 호출해 해당 아이디의 모든 회원정보 확인
+     */
+    MemberDTO searchDitail (String memberNo);
+
+
+    /*
+    [전체 회원 조회기능]
+    repo의 allLoadMember 호출해 해당 아이디의 모든 회원정보 확인
+     */
+    MemberDTO searchAll (String memberNo);
 
 
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -50,6 +50,11 @@ public interface MemberService {   /*
      */
     MemberDTO searchDitail (String memberNo);
 
+    /*
+      [권한별 조회 기능]
+      repo의 loadMember 호출해 해당 권한의 회원정보 확인
+       */
+    MemberDTO searchAuthority (String authority);
 
     /*
     [전체 회원 조회기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -77,5 +77,17 @@ public interface MemberService {   /*
      */
     String findPassword(String memberNo);
 
+    /*
+     * [인증번호 생성 기능]
+     * 이메일을 입력받고 -> 2차에서 이메일 발송까지 구현 예정
+     * 랜덤한 인증번호 6자리를 생성한다.
+     */
+    String randomNumber (String memberEmail);
+
+    /*
+     * [인증번호 유효왁인 기능]
+     * 사용자가 입력한 인증번호가 유효한지 확인한다.
+     */
+    boolean checkRandomNumber (String randomNumber);
 
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -32,6 +32,12 @@ public interface MemberService {   /*
      */
     MemberDTO requestMember(MemberDTO member);
 
+    /*
+    [회원아이디 중복검사 기능]
+    repo의 searchLoginfo를 호출 해당 아이디가 존재하는지 확인
+     */
+    MemberDTO checkId (String memberNo);
+
 
 
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -60,7 +60,7 @@ public interface MemberService {   /*
     [전체 회원 조회기능]
     repo의 allLoadMember 호출해 해당 아이디의 모든 회원정보 확인
      */
-    MemberDTO searchAll (String memberNo);
+    MemberDTO searchAll();
 
 
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -1,4 +1,31 @@
 package service;
 
-public interface MemberService {
+import dto.MemberDTO;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberService {   /*
+
+    /* [회원 등록 기능]
+    * repo의 add메서드 호출하여 데이터를 저장
+    */
+    MemberDTO addMember(MemberDTO member);
+
+    /*
+     * [회원 수정 기능]
+     * repo의 loadMember 호출하여 아이디를 전달해 정보 조회 후
+     * repo의 updateMember 호출하여 해당 아이디의 회원정보 update
+     */
+    MemberDTO updateMember(String memberNo, MemberDTO updateMember);
+
+
+    /*
+     * [회원 삭제 기능]
+     * repo의 loadMember 호출하여 아이디를 전달해 정보 조회 후
+     * repo의 deleteMember 호출하여 해당 아이디의 회원정보 update
+     */
+    MemberDTO deleteMember(String memberNo);
+
+
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -60,7 +60,7 @@ public interface MemberService {   /*
     [전체 회원 조회기능]
     repo의 allLoadMember 호출해 해당 아이디의 모든 회원정보 확인
      */
-    MemberDTO searchAll();
+    List<MemberDTO> searchAll();
 
 
     /*

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -26,4 +26,12 @@ public interface MemberService {   /*
      */
     MemberDTO deleteMember(String memberNo);
 
+    /*
+     * [회원 가입 기능]
+     * repo의 requestMember 호출하여 데이터를 저장
+     */
+    MemberDTO requestMember(MemberDTO member);
+
+
+
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -90,4 +90,10 @@ public interface MemberService {   /*
      */
     boolean checkRandomNumber (String randomNumber);
 
+    /*
+     * [회원 승인 기능]
+     * repo의 approvalMember 호출하여 해당  가맹점주의 가입상태를 승인으로 변경
+     */
+    MemberDTO approvalMember(String memberNo);
+
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -14,18 +14,16 @@ public interface MemberService {   /*
 
     /*
      * [회원 수정 기능]
-     * repo의 loadMember 호출하여 아이디를 전달해 정보 조회 후
      * repo의 updateMember 호출하여 해당 아이디의 회원정보 update
      */
-    MemberDTO updateMember(String memberNo, MemberDTO updateMember);
+    MemberDTO updateMember(MemberDTO updateMember);
 
 
     /*
      * [회원 삭제 기능]
      * repo의 loadMember 호출하여 아이디를 전달해 정보 조회 후
-     * repo의 deleteMember 호출하여 해당 아이디의 회원정보 update
+     * repo의 deleteMember 호출하여 해당 아이디의 회원정보 delete
      */
     MemberDTO deleteMember(String memberNo);
-
 
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -72,5 +72,10 @@ public class MemberServiceImpl implements MemberService {
         return false;
     }
 
+    @Override
+    public MemberDTO approvalMember(String memberNo) {
+        return null;
+    }
+
 
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -21,4 +21,9 @@ public class MemberServiceImpl implements MemberService {
     public MemberDTO deleteMember(String memberNo) {
         return null;
     }
+
+    @Override
+    public MemberDTO requestMember(MemberDTO member) {
+        return null;
+    }
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -62,5 +62,15 @@ public class MemberServiceImpl implements MemberService {
         return null;
     }
 
+    @Override
+    public String randomNumber(String memberEmail) {
+        return null;
+    }
+
+    @Override
+    public boolean checkRandomNumber(String randomNumber) {
+        return false;
+    }
+
 
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -43,6 +43,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public MemberDTO searchAuthority(String authority) {
+        return null;
+    }
+
+    @Override
     public MemberDTO searchAll(String memberNo) {
         return null;
     }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -26,4 +26,9 @@ public class MemberServiceImpl implements MemberService {
     public MemberDTO requestMember(MemberDTO member) {
         return null;
     }
+
+    @Override
+    public MemberDTO checkId(String memberNo) {
+        return null;
+    }
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -31,4 +31,19 @@ public class MemberServiceImpl implements MemberService {
     public MemberDTO checkId(String memberNo) {
         return null;
     }
+
+    @Override
+    public MemberDTO searchSimple(String memberNo) {
+        return null;
+    }
+
+    @Override
+    public MemberDTO searchDitail(String memberNo) {
+        return null;
+    }
+
+    @Override
+    public MemberDTO searchAll(String memberNo) {
+        return null;
+    }
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -1,8 +1,24 @@
 package service;
 
+import dto.MemberDTO;
 import repository.MemberRepo;
 
 public class MemberServiceImpl implements MemberService {
     public MemberServiceImpl(MemberRepo memberRepo) {
+    }
+
+    @Override
+    public MemberDTO addMember(MemberDTO member) {
+        return null;
+    }
+
+    @Override
+    public MemberDTO updateMember(String memberNo, MemberDTO updateMember) {
+        return null;
+    }
+
+    @Override
+    public MemberDTO deleteMember(String memberNo) {
+        return null;
     }
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -48,7 +48,9 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public MemberDTO searchAll(String memberNo) {
+    public MemberDTO searchAll() {
         return null;
     }
+
+
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -3,9 +3,10 @@ package service;
 import dto.MemberDTO;
 import repository.MemberRepo;
 
+import java.util.List;
+
 public class MemberServiceImpl implements MemberService {
-    public MemberServiceImpl(MemberRepo memberRepo) {
-    }
+
 
     @Override
     public MemberDTO addMember(MemberDTO member) {
@@ -48,7 +49,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public MemberDTO searchAll() {
+    public List<MemberDTO> searchAll() {
         return null;
     }
 
@@ -76,6 +77,4 @@ public class MemberServiceImpl implements MemberService {
     public MemberDTO approvalMember(String memberNo) {
         return null;
     }
-
-
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -52,5 +52,15 @@ public class MemberServiceImpl implements MemberService {
         return null;
     }
 
+    @Override
+    public String findId(String memberEmail) {
+        return null;
+    }
+
+    @Override
+    public String findPassword(String memberNo) {
+        return null;
+    }
+
 
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -13,7 +13,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public MemberDTO updateMember(String memberNo, MemberDTO updateMember) {
+    public MemberDTO updateMember(MemberDTO updateMember) {
         return null;
     }
 


### PR DESCRIPTION
#38 

## member service 기능정의
[회원 등록 기능]
- repo의 add메서드 호출하여 데이터를 저장

[회원 수정 기능]
- repo의 updateMember 호출하여 해당 아이디의 회원정보 update

[회원 삭제 기능]
- repo의 loadMember 호출하여 아이디를 전달해 정보 조회 후
- repo의 deleteMember 호출하여 해당 아이디의 회원정보 delete

[회원 가입 기능]
- repo의 requestMember 호출하여 데이터를 저장

[회원아이디 중복검사 기능]
- repo의 searchLoginfo를 호출 해당 아이디가 존재하는지 확인

[회원아이디 간편조회 기능]
- repo의 loadMember 호출해 해당 아이디의 아이디/이름/이메일 등 확인

[회원아이디 상세조회 기능]
- repo의 loadMember 호출해 해당 아이디의 모든 회원정보 확인

[권한별 조회 기능]
- repo의 loadMember 호출해 해당 권한의 회원정보 확인

[전체 회원 조회기능]
- repo의 allLoadMember 호출해 해당 아이디의 모든 회원정보 확인

[아이디 찾기 기능]
- searchLoginfo 호출
- 이메일로 아이디를 찾을 수 있다.

[비밀번호 찾기 기능]
- searchLoginfo 호출
- 아이디로 비밀번호를 찾을 수 있다.

[인증번호 생성 기능]
- 이메일을 입력받고 -> 2차에서 이메일 발송까지 구현 예정
- 랜덤한 인증번호 6자리를 생성한다.

[인증번호 유효왁인 기능]
- 사용자가 입력한 인증번호가 유효한지 확인한다.

[회원 승인 기능]
- repo의 approvalMember 호출하여 해당  가맹점주의 가입상태를 승인으로 변경



---
## 리뷰 요구사항

