### PR TITLE
Feat/member service

### DIFF
--- a/src/dto/memberDTO/MemberDTO.java
+++ b/src/dto/memberDTO/MemberDTO.java
@@ -6,6 +6,9 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class MemberDTO {
+    public MemberDTO() {
+    }
+
     /** 회원번호 */
     private int memberNo;
     /** 권한 아이디 */

--- a/src/dto/memberDTO/MemberDTO.java
+++ b/src/dto/memberDTO/MemberDTO.java
@@ -1,4 +1,27 @@
 package dto.memberDTO;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
 public class MemberDTO {
+    /** 회원번호 */
+    private int memberNo;
+    /** 권한 아이디 */
+    private int authorityId;
+    /** 회원 이름 */
+    private String name;
+    /** 회원 전화번호 */
+    private String phoneNumber;
+    /** 회원 이메일 */
+    private String email;
+    /** 회원 주소 */
+    private String address;
+    /** 회원 아이디 */
+    private String id;
+    /** 회원 비밀번호 */
+    private String password;
+    /* 로그인 상태 */
+    private String logstatus;
 }

--- a/src/dto/memberDTO/MemberRequestDTO.java
+++ b/src/dto/memberDTO/MemberRequestDTO.java
@@ -6,6 +6,9 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class MemberRequestDTO {
+    public MemberRequestDTO() {
+    }
+
     /** 권한 아이디 */
     private int authorityId;
     /** 회원 이름 */

--- a/src/dto/memberDTO/MemberRequestDTO.java
+++ b/src/dto/memberDTO/MemberRequestDTO.java
@@ -1,4 +1,26 @@
 package dto.memberDTO;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
 public class MemberRequestDTO {
+    /** 권한 아이디 */
+    private int authorityId;
+    /** 회원 이름 */
+    private String name;
+    /** 회원 전화번호 */
+    private String phoneNumber;
+    /** 회원 이메일 */
+    private String email;
+    /** 회원 주소 */
+    private String address;
+    /** 회원 아이디 */
+    private String id;
+    /** 회원 비밀번호 */
+    private String password;
+    /** 회원 승인요청 상태 **/
+    private String request;
+
 }

--- a/src/repository/MemberRepo.java
+++ b/src/repository/MemberRepo.java
@@ -60,7 +60,7 @@ public interface MemberRepo {
      * 가맹점주는 본인 아이디로 조회할 수 있다.
      * 회원이 존재하지 않을 경우  Optional 처리
      */
-    Optional<List<MemberDTO>> loadMember(String searchAttribut,String serchValue);
+    <T> Optional<List<MemberDTO>> loadMember(String searchAttribut,T serchValue);
 
     /*
      * [전체 회원 조회 기능]

--- a/src/repository/MemberRepo.java
+++ b/src/repository/MemberRepo.java
@@ -93,5 +93,5 @@ public interface MemberRepo {
      * 본사관리자는 가맹점주의 회원가입 요청 목록을 조회
      * 존재하지 않는 아이디의 경우  Optional 처리
     */
-    Optional<List<MemberRequestDTO>> loadRequestMember(String memberId);
+    Optional<List<MemberRequestDTO>> loadRequestMember();
 }

--- a/src/repository/MemberRepo.java
+++ b/src/repository/MemberRepo.java
@@ -50,7 +50,7 @@ public interface MemberRepo {
      * 존재하지 않는 아이디의 경우  Optional 처리
      * 트리거를 이용해 승인된 회원을 회원테이블에 추가 / 회원가입 요청 테이블에서 삭제
      */
-    Optional<String> approvalMember(String memberId);
+    boolean approvalMember(String memberId);
 
 
     /*

--- a/src/repository/MemberRepo.java
+++ b/src/repository/MemberRepo.java
@@ -1,6 +1,7 @@
 package repository;
 
 import dto.memberDTO.MemberDTO;
+import dto.memberDTO.MemberRequestDTO;
 import vo.memberVO.MemberReauestVO;
 import vo.memberVO.MemberVO;
 
@@ -14,7 +15,7 @@ public interface MemberRepo {
      * [회원 등록 기능]
      * 본사관리자가 신규 창고관리자를 등록
      */
-    Optional<MemberVO>insertMember(MemberVO member);
+    Optional<MemberDTO>insertMember(MemberDTO member);
 
     /*
      * [회원 수정 기능]
@@ -22,7 +23,7 @@ public interface MemberRepo {
      * 가맹점주는 본인 정보 수정
      * 수정하려는 회원이 없을 경우  Optional 처리
      */
-    Optional<MemberVO> updateMember(MemberVO updateMember);
+    Optional<MemberDTO> updateMember(MemberDTO updateMember);
 
 
     /*
@@ -41,7 +42,7 @@ public interface MemberRepo {
      * 요청상태 :승인대기
      * 승인 실패의 경우 : 이미 존재하는 아이디의 경우 예외처리
      */
-    Optional<MemberReauestVO> requestMember(MemberReauestVO member);
+    Optional<MemberRequestDTO> requestMember(MemberRequestDTO member);
 
     /*
      * [회원 승인 기능]
@@ -59,14 +60,14 @@ public interface MemberRepo {
      * 가맹점주는 본인 아이디로 조회할 수 있다.
      * 회원이 존재하지 않을 경우  Optional 처리
      */
-    Optional<List<MemberVO>> loadMember(String searchAttribut,String serchValue);
+    Optional<List<MemberDTO>> loadMember(String searchAttribut,String serchValue);
 
     /*
      * [전체 회원 조회 기능]
      * 저장된 전체 회원의 정보를 조회
      * 회원이 존재하지 않아 리스트가 null값일 경우 Optional처리
      */
-    Optional<List<MemberVO>> allLoadMember();
+    Optional<List<MemberDTO>> allLoadMember();
 
 
     /*
@@ -92,5 +93,5 @@ public interface MemberRepo {
      * 본사관리자는 가맹점주의 회원가입 요청 목록을 조회
      * 존재하지 않는 아이디의 경우  Optional 처리
     */
-    Optional<List<MemberReauestVO>> loadRequestMember(String memberId);
+    Optional<List<MemberRequestDTO>> loadRequestMember(String memberId);
 }

--- a/src/repository/MemberRepoImpl.java
+++ b/src/repository/MemberRepoImpl.java
@@ -163,14 +163,20 @@ public class MemberRepoImpl implements MemberRepo {
 
     //회원 검색 메서드
     @Override
-    public Optional<List<MemberDTO>> loadMember(String searchAttribute, String searchValue) {
+    public <T> Optional<List<MemberDTO>> loadMember(String searchAttribute, T searchValue) {
         List<MemberDTO> loadMemberList = new ArrayList<>();
         conn = DBUtil.getConnection();
         try {
             String sql = "{call searchMember(?,?)}";
             cs = conn.prepareCall(sql);
             cs.setString(1,searchAttribute);
-            cs.setString(2, searchValue);
+
+            //타입검사
+            //Integer 타입일 경우
+            if (searchValue instanceof Integer) {
+                cs.setInt(2, (Integer) searchValue);
+            } else cs.setString(2, (String) searchValue);
+
 
             rs = cs.executeQuery();
 
@@ -193,6 +199,7 @@ public class MemberRepoImpl implements MemberRepo {
             } else {
                 return Optional.of(Collections.emptyList());
             }
+
         } catch (SQLException e) {
             e.printStackTrace();
         }finally {

--- a/src/repository/MemberRepoImpl.java
+++ b/src/repository/MemberRepoImpl.java
@@ -293,13 +293,12 @@ public class MemberRepoImpl implements MemberRepo {
 
     //회원 가입 요청 조회 기능
     @Override
-    public Optional<List<MemberRequestDTO>> loadRequestMember(String memberId) {
+    public Optional<List<MemberRequestDTO>> loadRequestMember() {
         List<MemberRequestDTO> allLoadRequestMemberList = new ArrayList<>();
         conn =DBUtil.getConnection();
         try {
-            String sql = "{call loadRequestMember(?)}";
+            String sql = "{call loadRequestMember()}";
             cs = conn.prepareCall(sql);
-            cs.setString(1,memberId);
             rs = cs.executeQuery();
             while (rs.next()){
                 MemberRequestDTO MemberReauestDTO = new MemberRequestDTO();

--- a/src/repository/MemberRepoImpl.java
+++ b/src/repository/MemberRepoImpl.java
@@ -24,7 +24,7 @@ public class MemberRepoImpl implements MemberRepo {
 
     // 회원 등록 메서드
     @Override
-    public Optional<MemberVO> insertMember(MemberVO member) {
+    public Optional<MemberDTO> insertMember(MemberDTO member) {
         conn = DBUtil.getConnection();
 
         try {
@@ -56,7 +56,7 @@ public class MemberRepoImpl implements MemberRepo {
 
     // 회원 수정 메서드
     @Override
-    public Optional<MemberVO> updateMember(MemberVO updateMember) {
+    public Optional<MemberDTO> updateMember(MemberDTO updateMember) {
         conn =DBUtil.getConnection();
 
         try {
@@ -109,7 +109,7 @@ public class MemberRepoImpl implements MemberRepo {
 
     // 회원 가입 요청 메서드
     @Override
-    public Optional<MemberReauestVO> requestMember(MemberReauestVO member) {
+    public Optional<MemberRequestDTO> requestMember(MemberRequestDTO member) {
         conn = DBUtil.getConnection();
 
         try {
@@ -163,8 +163,8 @@ public class MemberRepoImpl implements MemberRepo {
 
     //회원 검색 메서드
     @Override
-    public Optional<List<MemberVO>> loadMember(String searchAttribute, String searchValue) {
-        List<MemberVO> loadMemberList = new ArrayList<>();
+    public Optional<List<MemberDTO>> loadMember(String searchAttribute, String searchValue) {
+        List<MemberDTO> loadMemberList = new ArrayList<>();
         conn = DBUtil.getConnection();
         try {
             String sql = "{call searchMember(?,?)}";
@@ -175,17 +175,17 @@ public class MemberRepoImpl implements MemberRepo {
             rs = cs.executeQuery();
 
             while (rs.next()){
-                MemberVO memberVO = new MemberVO();
-                memberVO.setMemberNo(rs.getInt("memberNo"));
-                memberVO.setAuthorityId(rs.getInt("authorityId"));
-                memberVO.setName(rs.getString("name"));
-                memberVO.setPhoneNumber(rs.getString("phoneNumber"));
-                memberVO.setEmail(rs.getString("email"));
-                memberVO.setAddress(rs.getString("address"));
-                memberVO.setId(rs.getString("id"));
-                memberVO.setPassword(rs.getString("password"));
-                memberVO.setLogstatus(rs.getString("logstatus"));
-                loadMemberList.add(memberVO);
+                MemberDTO memberDTO = new MemberDTO();
+                memberDTO.setMemberNo(rs.getInt("memberNo"));
+                memberDTO.setAuthorityId(rs.getInt("authorityId"));
+                memberDTO.setName(rs.getString("name"));
+                memberDTO.setPhoneNumber(rs.getString("phoneNumber"));
+                memberDTO.setEmail(rs.getString("email"));
+                memberDTO.setAddress(rs.getString("address"));
+                memberDTO.setId(rs.getString("id"));
+                memberDTO.setPassword(rs.getString("password"));
+                memberDTO.setLogstatus(rs.getString("logstatus"));
+                loadMemberList.add(memberDTO);
             }
 
             if (!loadMemberList.isEmpty()) {
@@ -203,8 +203,8 @@ public class MemberRepoImpl implements MemberRepo {
 
     //전체 회원 조회 기능
     @Override
-    public Optional<List<MemberVO>> allLoadMember() {
-        List<MemberVO> allLoadMemberList = new ArrayList<>();
+    public Optional<List<MemberDTO>> allLoadMember() {
+        List<MemberDTO> allLoadMemberList = new ArrayList<>();
         conn = DBUtil.getConnection();
         try {
             String sql = "{call loadMember()}";
@@ -212,17 +212,17 @@ public class MemberRepoImpl implements MemberRepo {
             rs = cs.executeQuery();
 
             while (rs.next()){
-                MemberVO memberVO = new MemberVO();
-                memberVO.setMemberNo(rs.getInt("memberNo"));
-                memberVO.setAuthorityId(rs.getInt("authorityId"));
-                memberVO.setName(rs.getString("name"));
-                memberVO.setPhoneNumber(rs.getString("phoneNumber"));
-                memberVO.setEmail(rs.getString("email"));
-                memberVO.setAddress(rs.getString("address"));
-                memberVO.setId(rs.getString("id"));
-                memberVO.setPassword(rs.getString("password"));
-                memberVO.setLogstatus(rs.getString("logstatus"));
-                allLoadMemberList.add(memberVO);
+                MemberDTO memberDTO = new MemberDTO();
+                memberDTO.setMemberNo(rs.getInt("memberNo"));
+                memberDTO.setAuthorityId(rs.getInt("authorityId"));
+                memberDTO.setName(rs.getString("name"));
+                memberDTO.setPhoneNumber(rs.getString("phoneNumber"));
+                memberDTO.setEmail(rs.getString("email"));
+                memberDTO.setAddress(rs.getString("address"));
+                memberDTO.setId(rs.getString("id"));
+                memberDTO.setPassword(rs.getString("password"));
+                memberDTO.setLogstatus(rs.getString("logstatus"));
+                allLoadMemberList.add(memberDTO);
             }
 
 
@@ -286,8 +286,8 @@ public class MemberRepoImpl implements MemberRepo {
 
     //회원 가입 요청 조회 기능
     @Override
-    public Optional<List<MemberReauestVO>> loadRequestMember(String memberId) {
-        List<MemberReauestVO> allLoadRequestMemberList = new ArrayList<>();
+    public Optional<List<MemberRequestDTO>> loadRequestMember(String memberId) {
+        List<MemberRequestDTO> allLoadRequestMemberList = new ArrayList<>();
         conn =DBUtil.getConnection();
         try {
             String sql = "{call loadRequestMember(?)}";
@@ -295,16 +295,16 @@ public class MemberRepoImpl implements MemberRepo {
             cs.setString(1,memberId);
             rs = cs.executeQuery();
             while (rs.next()){
-                MemberReauestVO MemberReauestVO = new MemberReauestVO();
-                MemberReauestVO.setAuthorityId(rs.getInt("authorityId"));
-                MemberReauestVO.setName(rs.getString("name"));
-                MemberReauestVO.setPhoneNumber(rs.getString("phoneNumber"));
-                MemberReauestVO.setEmail(rs.getString("email"));
-                MemberReauestVO.setAddress(rs.getString("address"));
-                MemberReauestVO.setId(rs.getString("id"));
-                MemberReauestVO.setPassword(rs.getString("password"));
-                MemberReauestVO.setRequest(rs.getString("request"));
-                allLoadRequestMemberList.add(MemberReauestVO);
+                MemberRequestDTO MemberReauestDTO = new MemberRequestDTO();
+                MemberReauestDTO.setAuthorityId(rs.getInt("authorityId"));
+                MemberReauestDTO.setName(rs.getString("name"));
+                MemberReauestDTO.setPhoneNumber(rs.getString("phoneNumber"));
+                MemberReauestDTO.setEmail(rs.getString("email"));
+                MemberReauestDTO.setAddress(rs.getString("address"));
+                MemberReauestDTO.setId(rs.getString("id"));
+                MemberReauestDTO.setPassword(rs.getString("password"));
+                MemberReauestDTO.setRequest(rs.getString("request"));
+                allLoadRequestMemberList.add(MemberReauestDTO);
             }
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/repository/MemberRepoImpl.java
+++ b/src/repository/MemberRepoImpl.java
@@ -141,7 +141,7 @@ public class MemberRepoImpl implements MemberRepo {
 
     //회원 승인 메서드
     @Override
-    public Optional<String> approvalMember(String memberId) {
+    public boolean approvalMember(String memberId) {
         conn = DBUtil.getConnection();
 
         try {
@@ -151,14 +151,14 @@ public class MemberRepoImpl implements MemberRepo {
             cs.setString(1,memberId);
             int rs = cs.executeUpdate();
 
-            if (rs > 0 ) return Optional.of(memberId);
-            else return Optional.empty();
+            if (rs > 0 ) return true;
+            else return false;
         } catch (SQLException e) {
             e.printStackTrace();
         }finally {
             DBUtil.closeQuietly(null,cs,conn);
         }
-        return Optional.empty();
+        return false;
     }
 
     //회원 검색 메서드

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -1,22 +1,21 @@
 package service;
 
 import dto.memberDTO.MemberDTO;
-import vo.memberVO.MemberVO;
 
 import java.util.List;
 
 public interface MemberService {   /*
 
     /* [회원 등록 기능]
-    * repo의 insertMember 호출하여 데이터를 저장
+    * repo의 insertMemberap 호출하여 데이터를 저장
     */
-    MemberVO addMember(MemberVO member);
+    MemberDTO addMember(MemberDTO member);
 
     /*
      * [회원 수정 기능]
      * repo의 updateMember 호출하여 해당 아이디의 회원정보 update
      */
-    MemberVO updateMember(MemberVO updateMember);
+    MemberDTO updateMember(MemberDTO updateMember);
 
 
     /*
@@ -24,43 +23,43 @@ public interface MemberService {   /*
      * repo의 loadMember 호출하여 아이디를 전달해 정보 조회 후
      * repo의 deleteMember 호출하여 해당 아이디의 회원정보 delete
      */
-    MemberVO deleteMember(String memberNo);
+    MemberDTO deleteMember(String memberNo);
 
     /*
      * [회원 가입 기능]
      * repo의 requestMember 호출하여 데이터를 저장
      */
-    MemberVO requestMember(MemberVO member);
+    MemberDTO requestMember(MemberDTO member);
 
     /*
     [회원아이디 중복검사 기능]
     repo의 searchLoginfo를 호출 해당 아이디가 존재하는지 확인
      */
-    MemberVO checkId (String memberNo);
+    MemberDTO checkId (String memberNo);
 
     /*
     [회원아이디 간편조회 기능]
     repo의 loadMember 호출해 해당 아이디의 아이디/이름/이메일 등 확인
      */
-    MemberVO searchSimple (String memberNo);
+    MemberDTO searchSimple (String memberNo);
 
     /*
     [회원아이디 상세조회 기능]
     repo의 loadMember 호출해 해당 아이디의 모든 회원정보 확인
      */
-    MemberVO searchDitail (String memberNo);
+    MemberDTO searchDitail (String memberNo);
 
     /*
       [권한별 조회 기능]
       repo의 loadMember 호출해 해당 권한의 회원정보 확인
        */
-    MemberVO searchAuthority (String authority);
+    MemberDTO searchAuthority (String authority);
 
     /*
     [전체 회원 조회기능]
     repo의 allLoadMember 호출해 해당 아이디의 모든 회원정보 확인
      */
-    List<MemberVO> searchAll();
+    List<MemberDTO> searchAll();
 
 
     /*
@@ -94,7 +93,7 @@ public interface MemberService {   /*
      * [회원 승인 기능]
      * repo의 approvalMember 호출하여 해당  가맹점주의 가입상태를 승인으로 변경
      */
-    MemberVO approvalMember(String memberNo);
+    MemberDTO approvalMember(String memberNo);
 
     /*
     [로그인 기능]
@@ -116,5 +115,5 @@ public interface MemberService {   /*
     [회원가입 요청 조회 기능]
     repo의 loadRequestMember 호출해 해당 권한의 회원정보 확인
     */
-     List<MemberVO> searchRequestMember ();
+     List<MemberDTO> searchRequestMember ();
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -115,7 +115,7 @@ public interface MemberService {   /*
     [회원가입 요청 조회 기능]
     repo의 loadRequestMember 호출해 해당 권한의 회원정보 확인
     */
-     List<MemberDTO> searchRequestMember ();
+     List<MemberRequestDTO> searchRequestMember ();
 
      /*
      [로그인 상태 확인 기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -41,19 +41,19 @@ public interface MemberService {   /*
     [회원아이디 간편조회 기능]
     repo의 loadMember 호출해 해당 아이디의 아이디/이름/이메일 등 확인
      */
-    MemberDTO searchSimple (String memberNo);
+    MemberDTO searchSimple (String memberId);
 
     /*
     [회원아이디 상세조회 기능]
     repo의 loadMember 호출해 해당 아이디의 모든 회원정보 확인
      */
-    MemberDTO searchDitail (String memberNo);
+    MemberDTO searchDitail (String memberId);
 
     /*
       [권한별 조회 기능]
       repo의 loadMember 호출해 해당 권한의 회원정보 확인
        */
-    MemberDTO searchAuthority (String authority);
+    List<MemberDTO>  searchAuthority (String authority);
 
     /*
     [전체 회원 조회기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -93,7 +93,7 @@ public interface MemberService {   /*
      * [회원 승인 기능]
      * repo의 approvalMember 호출하여 해당  가맹점주의 가입상태를 승인으로 변경
      */
-    MemberDTO approvalMember(String memberNo);
+    String approvalMember(String memberNo);
 
     /*
     [로그인 기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -97,11 +97,11 @@ public interface MemberService {   /*
 
     /*
     [로그인 기능]
-    searchLoginfo호출하여 회원의 현재 로그상태를 확인 후
+    searchLoginfo 호출하여 회원의 현재 로그상태를 확인 후
     로그아웃상태라면 logInnOut 호출하여 로그상태 변경
     로그인 상태라면 거절
      */
-     String logIn(String memberid);
+     String logIn(String memberId);
 
      /*
     [로그아웃 기능]
@@ -109,11 +109,17 @@ public interface MemberService {   /*
     로그인상태라면 logInnOut 호출하여 로그상태 변경
     로그아웃 상태라면 거절
      */
-     String logOut(String memberid);
+     String logOut(String memberId);
 
      /*
     [회원가입 요청 조회 기능]
     repo의 loadRequestMember 호출해 해당 권한의 회원정보 확인
     */
      List<MemberDTO> searchRequestMember ();
+
+     /*
+     [로그인 상태 확인 기능]
+     */
+     public String logstatus(String memberId);
+
 }

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -81,13 +81,13 @@ public interface MemberService {   /*
      * 이메일을 입력받고 -> 2차에서 이메일 발송까지 구현 예정
      * 랜덤한 인증번호 6자리를 생성한다.
      */
-    String randomNumber ();
+    String randomNumber (String memberEmail);
 
     /*
      * [인증번호 유효왁인 기능]
      * 사용자가 입력한 인증번호가 유효한지 확인한다.
      */
-    boolean checkRandomNumber (String randomNumber);
+    boolean checkRandomNumber (String memberEmail,String userRandomNumber);
 
     /*
      * [회원 승인 기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -74,7 +74,7 @@ public interface MemberService {   /*
      * searchLoginfo 호출
      * 아이디로 비밀번호를 찾을 수 있다.
      */
-    String findPassword(String memberNo);
+    String findPassword(String memberId);
 
     /*
      * [인증번호 생성 기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -1,6 +1,7 @@
 package service;
 
 import dto.memberDTO.MemberDTO;
+import dto.memberDTO.MemberRequestDTO;
 
 import java.util.List;
 
@@ -20,7 +21,7 @@ public interface MemberService {   /*
 
     /*
      * [회원 삭제 기능]
-    * repo의 deleteMember 호출하여 해당 아이디의 회원정보 delete
+     * repo의 deleteMember 호출하여 해당 아이디의 회원정보 delete
      */
     String deleteMember(String memberId);
 
@@ -28,7 +29,7 @@ public interface MemberService {   /*
      * [회원 가입 기능]
      * repo의 requestMember 호출하여 데이터를 저장
      */
-    MemberDTO requestMember(MemberDTO member);
+    MemberRequestDTO requestMember(MemberRequestDTO member);
 
     /*
     [회원아이디 중복검사 기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -35,7 +35,7 @@ public interface MemberService {   /*
     [회원아이디 중복검사 기능]
     repo의 searchLoginfo를 호출 해당 아이디가 존재하는지 확인
      */
-    String checkId (String memberId);
+    boolean checkId (String memberId);
 
     /*
     [회원아이디 간편조회 기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -35,7 +35,7 @@ public interface MemberService {   /*
     [회원아이디 중복검사 기능]
     repo의 searchLoginfo를 호출 해당 아이디가 존재하는지 확인
      */
-    MemberDTO checkId (String memberNo);
+    String checkId (String memberId);
 
     /*
     [회원아이디 간편조회 기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -20,10 +20,9 @@ public interface MemberService {   /*
 
     /*
      * [회원 삭제 기능]
-     * repo의 loadMember 호출하여 아이디를 전달해 정보 조회 후
-     * repo의 deleteMember 호출하여 해당 아이디의 회원정보 delete
+    * repo의 deleteMember 호출하여 해당 아이디의 회원정보 delete
      */
-    MemberDTO deleteMember(String memberNo);
+    String deleteMember(String memberId);
 
     /*
      * [회원 가입 기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -81,7 +81,7 @@ public interface MemberService {   /*
      * 이메일을 입력받고 -> 2차에서 이메일 발송까지 구현 예정
      * 랜덤한 인증번호 6자리를 생성한다.
      */
-    String randomNumber (String memberEmail);
+    String randomNumber ();
 
     /*
      * [인증번호 유효왁인 기능]

--- a/src/service/MemberService.java
+++ b/src/service/MemberService.java
@@ -1,21 +1,22 @@
 package service;
 
 import dto.memberDTO.MemberDTO;
+import vo.memberVO.MemberVO;
 
 import java.util.List;
 
 public interface MemberService {   /*
 
     /* [회원 등록 기능]
-    * repo의 add메서드 호출하여 데이터를 저장
+    * repo의 insertMember 호출하여 데이터를 저장
     */
-    MemberDTO addMember(MemberDTO member);
+    MemberVO addMember(MemberVO member);
 
     /*
      * [회원 수정 기능]
      * repo의 updateMember 호출하여 해당 아이디의 회원정보 update
      */
-    MemberDTO updateMember(MemberDTO updateMember);
+    MemberVO updateMember(MemberVO updateMember);
 
 
     /*
@@ -23,43 +24,43 @@ public interface MemberService {   /*
      * repo의 loadMember 호출하여 아이디를 전달해 정보 조회 후
      * repo의 deleteMember 호출하여 해당 아이디의 회원정보 delete
      */
-    MemberDTO deleteMember(String memberNo);
+    MemberVO deleteMember(String memberNo);
 
     /*
      * [회원 가입 기능]
      * repo의 requestMember 호출하여 데이터를 저장
      */
-    MemberDTO requestMember(MemberDTO member);
+    MemberVO requestMember(MemberVO member);
 
     /*
     [회원아이디 중복검사 기능]
     repo의 searchLoginfo를 호출 해당 아이디가 존재하는지 확인
      */
-    MemberDTO checkId (String memberNo);
+    MemberVO checkId (String memberNo);
 
     /*
     [회원아이디 간편조회 기능]
     repo의 loadMember 호출해 해당 아이디의 아이디/이름/이메일 등 확인
      */
-    MemberDTO searchSimple (String memberNo);
+    MemberVO searchSimple (String memberNo);
 
     /*
     [회원아이디 상세조회 기능]
     repo의 loadMember 호출해 해당 아이디의 모든 회원정보 확인
      */
-    MemberDTO searchDitail (String memberNo);
+    MemberVO searchDitail (String memberNo);
 
     /*
       [권한별 조회 기능]
       repo의 loadMember 호출해 해당 권한의 회원정보 확인
        */
-    MemberDTO searchAuthority (String authority);
+    MemberVO searchAuthority (String authority);
 
     /*
     [전체 회원 조회기능]
     repo의 allLoadMember 호출해 해당 아이디의 모든 회원정보 확인
      */
-    List<MemberDTO> searchAll();
+    List<MemberVO> searchAll();
 
 
     /*
@@ -93,7 +94,7 @@ public interface MemberService {   /*
      * [회원 승인 기능]
      * repo의 approvalMember 호출하여 해당  가맹점주의 가입상태를 승인으로 변경
      */
-    MemberDTO approvalMember(String memberNo);
+    MemberVO approvalMember(String memberNo);
 
     /*
     [로그인 기능]
@@ -115,5 +116,5 @@ public interface MemberService {   /*
     [회원가입 요청 조회 기능]
     repo의 loadRequestMember 호출해 해당 권한의 회원정보 확인
     */
-     List<MemberDTO> searchRequestMember ();
+     List<MemberVO> searchRequestMember ();
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -1,6 +1,7 @@
 package service;
 
 import dto.memberDTO.MemberDTO;
+import dto.memberDTO.MemberRequestDTO;
 import repository.MemberRepo;
 
 import java.util.List;
@@ -36,9 +37,11 @@ public class MemberServiceImpl implements MemberService {
         return result.orElse(null);
     }
 
+    //회원 가입 기능
     @Override
-    public MemberDTO requestMember(MemberDTO member) {
-        return null;
+    public MemberRequestDTO requestMember(MemberRequestDTO member) {
+        Optional<MemberRequestDTO> result = memberRepo.requestMember(member);
+        return result.orElse(null);
     }
 
     @Override

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -46,9 +46,8 @@ public class MemberServiceImpl implements MemberService {
 
     //회원아이디 중복검사 기능
     @Override
-    public String checkId(String memberId) {
-        Optional<String> result = memberRepo.searchLoginfo("memberNo","id",memberId);
-        return result.isPresent() ? "존재하는 아이디" : "존재하지 않는 아이디";
+    public boolean  checkId(String memberId) {
+        return memberRepo.searchLoginfo("memberNo","id",memberId).isPresent();
     }
 
     //회원아이디 간편조회 기능

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -2,55 +2,60 @@ package service;
 
 import dto.memberDTO.MemberDTO;
 import repository.MemberRepo;
+import vo.memberVO.MemberVO;
 
 import java.util.List;
 
 public class MemberServiceImpl implements MemberService {
+    MemberRepo memberRepo;
+
     public MemberServiceImpl(MemberRepo memberRepo) {
+        this.memberRepo = memberRepo;
     }
 
+    //회원 등록 기능
     @Override
-    public MemberDTO addMember(MemberDTO member) {
+    public MemberVO addMember(MemberVO member) {
         return null;
     }
 
     @Override
-    public MemberDTO updateMember(MemberDTO updateMember) {
+    public MemberVO updateMember(MemberVO updateMember) {
         return null;
     }
 
     @Override
-    public MemberDTO deleteMember(String memberNo) {
+    public MemberVO deleteMember(String memberNo) {
         return null;
     }
 
     @Override
-    public MemberDTO requestMember(MemberDTO member) {
+    public MemberVO requestMember(MemberVO member) {
         return null;
     }
 
     @Override
-    public MemberDTO checkId(String memberNo) {
+    public MemberVO checkId(String memberNo) {
         return null;
     }
 
     @Override
-    public MemberDTO searchSimple(String memberNo) {
+    public MemberVO searchSimple(String memberNo) {
         return null;
     }
 
     @Override
-    public MemberDTO searchDitail(String memberNo) {
+    public MemberVO searchDitail(String memberNo) {
         return null;
     }
 
     @Override
-    public MemberDTO searchAuthority(String authority) {
+    public MemberVO searchAuthority(String authority) {
         return null;
     }
 
     @Override
-    public List<MemberDTO> searchAll() {
+    public List<MemberVO> searchAll() {
         return null;
     }
 
@@ -75,7 +80,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public MemberDTO approvalMember(String memberNo) {
+    public MemberVO approvalMember(String memberNo) {
         return null;
     }
 
@@ -90,7 +95,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public List<MemberDTO> searchRequestMember() {
+    public List<MemberVO> searchRequestMember() {
         return null;
     }
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -25,7 +25,8 @@ public class MemberServiceImpl implements MemberService {
     //회원 수정 기능
     @Override
     public MemberDTO updateMember(MemberDTO updateMember) {
-        return null;
+        Optional<MemberDTO> result = memberRepo.updateMember(updateMember);
+        return result.orElse(null);
     }
 
     @Override

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -83,9 +83,11 @@ public class MemberServiceImpl implements MemberService {
         return result.orElse(Collections.emptyList());
     }
 
+    //전체 회원 조회기능
     @Override
     public List<MemberDTO> searchAll() {
-        return null;
+        Optional<List<MemberDTO>> result = memberRepo.allLoadMember();
+        return result.orElse(Collections.emptyList());
     }
 
     @Override

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -121,18 +121,29 @@ public class MemberServiceImpl implements MemberService {
         else return "fail";
     }
 
+    //로그인 기능
     @Override
-    public String logIn(String memberid) {
-        return null;
+    public String logIn(String memberId) {
+        Optional<String> result = memberRepo.logInnOut(memberId);
+        return result.orElse(null);
     }
 
+    //로그아웃 기능
     @Override
-    public String logOut(String memberid) {
-        return null;
+    public String logOut(String memberId) {
+        Optional<String> result = memberRepo.logInnOut(memberId);
+        return result.orElse(null);
     }
 
     @Override
     public List<MemberDTO> searchRequestMember() {
         return null;
+    }
+
+    //로그인 상태 확인 기능
+    @Override
+    public String logstatus(String memberId){
+        Optional<String> result = memberRepo.searchLoginfo("logstatus","id",memberId);
+        return result.orElse(null);
     }
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -135,9 +135,11 @@ public class MemberServiceImpl implements MemberService {
         return result.orElse(null);
     }
 
+    //회원가입 요청 조회 기능
     @Override
-    public List<MemberDTO> searchRequestMember() {
-        return null;
+    public List<MemberRequestDTO> searchRequestMember() {
+        Optional<List<MemberRequestDTO>> result = memberRepo.loadRequestMember();
+        return result.orElse(Collections.emptyList());
     }
 
     //로그인 상태 확인 기능

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -2,7 +2,6 @@ package service;
 
 import dto.memberDTO.MemberDTO;
 import repository.MemberRepo;
-import vo.memberVO.MemberVO;
 
 import java.util.List;
 
@@ -15,47 +14,47 @@ public class MemberServiceImpl implements MemberService {
 
     //회원 등록 기능
     @Override
-    public MemberVO addMember(MemberVO member) {
+    public MemberDTO addMember(MemberDTO member) {
         return null;
     }
 
     @Override
-    public MemberVO updateMember(MemberVO updateMember) {
+    public MemberDTO updateMember(MemberDTO updateMember) {
         return null;
     }
 
     @Override
-    public MemberVO deleteMember(String memberNo) {
+    public MemberDTO deleteMember(String memberNo) {
         return null;
     }
 
     @Override
-    public MemberVO requestMember(MemberVO member) {
+    public MemberDTO requestMember(MemberDTO member) {
         return null;
     }
 
     @Override
-    public MemberVO checkId(String memberNo) {
+    public MemberDTO checkId(String memberNo) {
         return null;
     }
 
     @Override
-    public MemberVO searchSimple(String memberNo) {
+    public MemberDTO searchSimple(String memberNo) {
         return null;
     }
 
     @Override
-    public MemberVO searchDitail(String memberNo) {
+    public MemberDTO searchDitail(String memberNo) {
         return null;
     }
 
     @Override
-    public MemberVO searchAuthority(String authority) {
+    public MemberDTO searchAuthority(String authority) {
         return null;
     }
 
     @Override
-    public List<MemberVO> searchAll() {
+    public List<MemberDTO> searchAll() {
         return null;
     }
 
@@ -80,7 +79,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public MemberVO approvalMember(String memberNo) {
+    public MemberDTO approvalMember(String memberNo) {
         return null;
     }
 
@@ -95,7 +94,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public List<MemberVO> searchRequestMember() {
+    public List<MemberDTO> searchRequestMember() {
         return null;
     }
 }

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -44,9 +44,11 @@ public class MemberServiceImpl implements MemberService {
         return result.orElse(null);
     }
 
+    //회원아이디 중복검사 기능
     @Override
-    public MemberDTO checkId(String memberNo) {
-        return null;
+    public String checkId(String memberId) {
+        Optional<String> result = memberRepo.searchLoginfo("memberNo","id",memberId);
+        return result.isPresent() ? "존재하는 아이디" : "존재하지 않는 아이디";
     }
 
     @Override

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -7,9 +7,11 @@ import repository.MemberRepo;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 public class MemberServiceImpl implements MemberService {
     MemberRepo memberRepo;
+    private String randomNumber;
 
     public MemberServiceImpl(MemberRepo memberRepo) {
         this.memberRepo = memberRepo;
@@ -103,13 +105,22 @@ public class MemberServiceImpl implements MemberService {
         Optional<String> result = memberRepo.searchLoginfo("password","id",memberId);
         return result.orElse(null); }
 
+    //인증번호 생성 기능
     @Override
-    public String randomNumber(String memberEmail) {
-        return null;
+    public String randomNumber() {
+        // 6자리 랜덤 숫자 생성
+        // 100000~999999 사이의 랜덤 숫자 생성
+        randomNumber = String.valueOf((int) (Math.random() * 900000) + 100000);
+        return randomNumber;
     }
 
+    //인증번호 유효왁인 기능
     @Override
-    public boolean checkRandomNumber(String randomNumber) {
+    public boolean checkRandomNumber(String userrandomNumber) {
+        if (userrandomNumber.equals(randomNumber)) {
+            randomNumber = null; // 인증번호 폐기
+            return true;
+        }
         return false;
     }
 

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import dto.memberDTO.MemberDTO;
 import repository.MemberRepo;
 
 import java.util.List;
+import java.util.Optional;
 
 public class MemberServiceImpl implements MemberService {
     MemberRepo memberRepo;
@@ -15,9 +16,13 @@ public class MemberServiceImpl implements MemberService {
     //회원 등록 기능
     @Override
     public MemberDTO addMember(MemberDTO member) {
-        return null;
+        //insertMember 반환된 객체를 result 에 저장
+        Optional<MemberDTO> result = memberRepo.insertMember(member);
+        //결과값을 반환, 하지만 결과값이 optional.empty면 null 반환
+        return result.orElse(null);
     }
 
+    //회원 수정 기능
     @Override
     public MemberDTO updateMember(MemberDTO updateMember) {
         return null;

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import dto.memberDTO.MemberDTO;
 import dto.memberDTO.MemberRequestDTO;
 import repository.MemberRepo;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,19 +52,35 @@ public class MemberServiceImpl implements MemberService {
         return result.isPresent() ? "존재하는 아이디" : "존재하지 않는 아이디";
     }
 
+    //회원아이디 간편조회 기능
     @Override
-    public MemberDTO searchSimple(String memberNo) {
-        return null;
+    public MemberDTO searchSimple(String memberId) {
+        Optional<List<MemberDTO>> result = memberRepo.loadMember("id",memberId);
+        return result.filter(list -> !list.isEmpty())
+                .map(list -> list.get(0))  // 첫 번째 객체를 꺼냄
+                .orElse(null);
     }
 
+    //회원아이디 상세조회 기능
     @Override
-    public MemberDTO searchDitail(String memberNo) {
-        return null;
+    public MemberDTO searchDitail(String memberId) {
+        Optional<List<MemberDTO>> result = memberRepo.loadMember("id",memberId);
+        return result.filter(list -> !list.isEmpty())
+                .map(list -> list.get(0))
+                .orElse(null);
     }
 
+    //권한별 조회 기능
     @Override
-    public MemberDTO searchAuthority(String authority) {
-        return null;
+    public List<MemberDTO> searchAuthority(String authority) {
+        int authorityId = 0;
+
+        if (authority.equals("총관리자")) authorityId = 1;
+        else if (authority.equals("창고관리자"))authorityId = 2;
+        else authorityId = 3;
+
+        Optional<List<MemberDTO>> result = memberRepo.loadMember("authorityId", authorityId);
+        return result.orElse(Collections.emptyList());
     }
 
     @Override

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -29,9 +29,11 @@ public class MemberServiceImpl implements MemberService {
         return result.orElse(null);
     }
 
+    //회원 삭제 기능
     @Override
-    public MemberDTO deleteMember(String memberNo) {
-        return null;
+    public String deleteMember(String memberId) {
+        Optional<String> result = memberRepo.deleteMember(memberId);
+        return result.orElse(null);
     }
 
     @Override

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -90,15 +90,18 @@ public class MemberServiceImpl implements MemberService {
         return result.orElse(Collections.emptyList());
     }
 
+    //아이디 찾기 기능
     @Override
     public String findId(String memberEmail) {
-        return null;
+        Optional<String> result = memberRepo.searchLoginfo("id","email",memberEmail);
+        return result.orElse(null);
     }
 
+    //비밀번호 찾기 기능
     @Override
-    public String findPassword(String memberNo) {
-        return null;
-    }
+    public String findPassword(String memberId) {
+        Optional<String> result = memberRepo.searchLoginfo("password","id",memberId);
+        return result.orElse(null); }
 
     @Override
     public String randomNumber(String memberEmail) {

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -4,14 +4,11 @@ import dto.memberDTO.MemberDTO;
 import dto.memberDTO.MemberRequestDTO;
 import repository.MemberRepo;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
 
 public class MemberServiceImpl implements MemberService {
     MemberRepo memberRepo;
-    private String randomNumber;
+    private Map<String, String> randomNumber = new HashMap<>();
 
     public MemberServiceImpl(MemberRepo memberRepo) {
         this.memberRepo = memberRepo;
@@ -107,18 +104,20 @@ public class MemberServiceImpl implements MemberService {
 
     //인증번호 생성 기능
     @Override
-    public String randomNumber() {
+    public String randomNumber(String memberEmail) {
         // 6자리 랜덤 숫자 생성
         // 100000~999999 사이의 랜덤 숫자 생성
-        randomNumber = String.valueOf((int) (Math.random() * 900000) + 100000);
-        return randomNumber;
+        String random = String.valueOf((int) (Math.random() * 900000) + 100000);
+        randomNumber.put(memberEmail,random);
+        return random;
     }
 
     //인증번호 유효왁인 기능
     @Override
-    public boolean checkRandomNumber(String userrandomNumber) {
-        if (userrandomNumber.equals(randomNumber)) {
-            randomNumber = null; // 인증번호 폐기
+    public boolean checkRandomNumber(String memberEmail, String userRandomNumber) {
+        //email(키)가 존재하고, 키의 값(인증번호)이 유저가 입력한 인증번호와 같다면, 인증번호 폐기 후 true 리턴
+        if (randomNumber.containsKey(memberEmail) && randomNumber.get(memberEmail).equals(userRandomNumber)) {
+           randomNumber.remove(memberEmail); // 인증번호 폐기
             return true;
         }
         return false;

--- a/src/service/MemberServiceImpl.java
+++ b/src/service/MemberServiceImpl.java
@@ -113,9 +113,12 @@ public class MemberServiceImpl implements MemberService {
         return false;
     }
 
+    //회원 승인 기능
     @Override
-    public MemberDTO approvalMember(String memberNo) {
-        return null;
+    public String approvalMember(String memberId) {
+        boolean approval = memberRepo.approvalMember(memberId);
+        if (approval) return "success";
+        else return "fail";
     }
 
     @Override

--- a/src/vo/memberVO/MemberReauestVO.java
+++ b/src/vo/memberVO/MemberReauestVO.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-@AllArgsConstructor
 public class MemberReauestVO {
     /** 권한 아이디 */
     private int authorityId;
@@ -23,6 +22,4 @@ public class MemberReauestVO {
     /** 회원 승인요청 상태 **/
     private String request;
 
-    public MemberReauestVO() {
-    }
 }

--- a/src/vo/memberVO/MemberVO.java
+++ b/src/vo/memberVO/MemberVO.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-@AllArgsConstructor
 /** 회원 테이블 */
 public class MemberVO {
     /** 회원번호 */
@@ -25,5 +24,4 @@ public class MemberVO {
     private String password;
     /* 로그인 상태 */
     private String logstatus;
-    public MemberVO() {}
 }


### PR DESCRIPTION
#49 

## member service 기능 구현 
 
[회원 등록]기능 구현
- repo의 updateMember 호출, DTO 객체 전달

[회원 수정]기능 구현
- repo의 updateMember 호출,DTO 객체 전달

[회원 삭제 ]기능 구현
- repo의 deleteMember 호출,DTO 객체 전달

[회원 가입 ]기능 구현
- repo의 requestMember 호출,DTO 객체 전달

[회원아이디 중복검사] 기능 구현
- repo의 searchLoginfo 호출
- 해당 아이디를 가진 회원이 있으면 true , 없으면 false

[아이디로 검색/ 권한별 검색 ]기능 구현
- memberRepo의 loadMember 호출하여 원하는 속성 검색 수행

[전체 회원 조회 ]기능 구현
- repo의 allLoadMember 호출

[아이디/비밀번호 찾기 ]기능 구현
- repo의 searchLoginfo 호출


[회원 승인 ]기능 구현
- repo의 approvalMember 호출
-  service 단에서 성공/실패 메세지 출력

[로그인/로그아웃/로그인상태확인 ]기능 구현
- repo의 logInnOut 호출하여 login/out 상태변경
- repo의 searchLoginfo 호출하여 해당 아이디의 로그인상태 확인

[회원가입요청 조회 ]기능 구현
- repo의 loadRequestMember 호출

[인증번호 생성/ 검증 ]기능 구현
- map에 키로 회원 이메일, 값으로 인증번호를 저장하여 많은 회원이 인증번호를 생성할 경우를 대비
- map에 키 값이 존재한다면 유효검사 후 폐기, 유효하지 않다면 여전히 존재 ( 컨트롤부분에서 해당 시스템 종료시 폐기할 예정)

